### PR TITLE
Add gemini-2.5-pro-preview env file

### DIFF
--- a/.env.openrouter-gemini-2.5-pro
+++ b/.env.openrouter-gemini-2.5-pro
@@ -1,0 +1,6 @@
+LLM_API_KEY=
+LLM_PROVIDER="OpenRouter"
+LLM_MODEL="openrouter/google/gemini-2.5-pro-preview"
+AGENT_MEMORY_ENABLED="true"
+SECURITY_CONFIRMATION_MODE="true"
+CONTAINER_NAME="OHA"


### PR DESCRIPTION
### **PR Type**
Configuration

___

### **PR Description**
- Added new environment file `.env.openrouter-gemini-2.5-pro` for Gemini 2.5 Pro model.

- Configured OpenRouter as the LLM provider with `google/gemini-2.5-pro-preview` model.

- Enabled agent memory and security confirmation mode by default.

- Set container name to `OHA`.
