### PR TITLE
Add core config to disable browser environment

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -3,6 +3,9 @@ search_api_key = "tvly-***"
 reasoning_effort = "high"
 platform = "linux/amd64" # Can be linux/amd64 or linux/arm64
 
+# Enable the browser environment
+enable_browser = true
+
 [llm]
 api_key = "sk-proj-***"
 # API base URL (For Headless / CLI only -  In Web this is overridden by Session Init)
@@ -10,3 +13,9 @@ api_key = "sk-proj-***"
 provider = "openai" # Can be openai, anthropic, deepseek, openrouter
 # Model to use. (For Headless / CLI only -  In Web this is overridden by Session Init)
 model = "openai/o3"
+
+[agent]
+
+# Whether the browsing tool is enabled
+# Note: when this is set to true, enable_browser in the core config must also be true
+enable_browsing = true


### PR DESCRIPTION
### **PR Type**
Configuration, Enhancement

___

### **PR Description**
- Added `enable_browser` configuration option to control browser environment.

- Added `enable_browsing` agent configuration with dependency on core `enable_browser` setting.
