### PR TITLE
Add support configuration

### DIFF
--- a/config.openrouter-moonshotai-kimi-k2.toml
+++ b/config.openrouter-moonshotai-kimi-k2.toml
@@ -1,0 +1,10 @@
+[core]
+search_api_key = "tvly-***"
+
+[llm]
+api_key = "sk-or-***"
+provider = "openrouter"
+model = "moonshotai/kimi-k2"
+
+[sandbox]
+platform = "linux/amd64"

--- a/config.openrouter-x-ai-grok-4.toml
+++ b/config.openrouter-x-ai-grok-4.toml
@@ -1,0 +1,11 @@
+[core]
+search_api_key = "tvly-***"
+
+[llm]
+api_key = "sk-or-***"
+provider = "openrouter"
+model = "x-ai/grok-4"
+reasoning_effort = "high"
+
+[sandbox]
+platform = "linux/amd64"


### PR DESCRIPTION
### **PR Type**
Configuration

___

### **PR Description**
- Added new configuration files for OpenRouter models:
  * `config.openrouter-moonshotai-kimi-k2.toml` for MoonshotAI's Kimi-K2 model.
  * `config.openrouter-x-ai-grok-4.toml` for xAI's Grok-4 model.

- Configured API keys and provider settings for both models.

- Set sandbox platform to `linux/amd64` for both configurations.

- Added `reasoning_effort` parameter for Grok-4 model.
